### PR TITLE
ci: 週次デプロイPR自動作成ワークフローを追加

### DIFF
--- a/.github/workflows/weekly-deploy-pr.yml
+++ b/.github/workflows/weekly-deploy-pr.yml
@@ -2,7 +2,7 @@ name: 週次デプロイPR作成
 
 on:
   schedule:
-    - cron: '0 0 * * 1' # 毎週月曜日 09:00 JST (00:00 UTC)
+    - cron: "0 0 * * 1" # 毎週月曜日 09:00 JST (00:00 UTC)
   workflow_dispatch:
 
 jobs:
@@ -14,7 +14,7 @@ jobs:
       pull-requests: write
 
     env:
-      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GH_TOKEN: ${{ secrets.GH_TOKEN }}
 
     steps:
       - name: Checkout

--- a/.github/workflows/weekly-deploy-pr.yml
+++ b/.github/workflows/weekly-deploy-pr.yml
@@ -19,8 +19,6 @@ jobs:
           fetch-depth: 0
 
       - name: 前週のデプロイPRをクローズ
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           prs=$(gh pr list --base main --head develop --state open --json number --jq '.[].number')
           if [ -n "$prs" ]; then
@@ -55,7 +53,6 @@ jobs:
       - name: PRを作成
         if: steps.get_changes.outputs.no_changes == 'false'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CHANGES: ${{ steps.get_changes.outputs.changes }}
         run: |
           DATE=$(TZ=Asia/Tokyo date '+%Y/%m/%d')

--- a/.github/workflows/weekly-deploy-pr.yml
+++ b/.github/workflows/weekly-deploy-pr.yml
@@ -9,7 +9,8 @@ jobs:
   create-deploy-pr:
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      id-token: write
+      contents: write
       pull-requests: write
 
     steps:

--- a/.github/workflows/weekly-deploy-pr.yml
+++ b/.github/workflows/weekly-deploy-pr.yml
@@ -1,0 +1,80 @@
+name: 週次デプロイPR作成
+
+on:
+  schedule:
+    - cron: '0 0 * * 1' # 毎週月曜日 09:00 JST (00:00 UTC)
+  workflow_dispatch:
+
+jobs:
+  create-deploy-pr:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: 前週のデプロイPRをクローズ
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          prs=$(gh pr list --base main --head develop --state open --json number --jq '.[].number')
+          if [ -n "$prs" ]; then
+            for pr in $prs; do
+              echo "Closing PR #$pr"
+              gh pr close "$pr" --comment "新しい週次デプロイPRが作成されるためクローズします。"
+            done
+          fi
+
+      - name: 変更内容を取得
+        id: get_changes
+        run: |
+          git fetch origin main develop
+
+          CHANGES=$(git log origin/main..origin/develop --pretty=format:"- %s (%h)" --no-merges)
+
+          if [ -z "$CHANGES" ]; then
+            echo "no_changes=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "no_changes=false" >> "$GITHUB_OUTPUT"
+            {
+              echo "changes<<EOF_CHANGES"
+              echo "$CHANGES"
+              echo "EOF_CHANGES"
+            } >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: 変更なしをスキップ
+        if: steps.get_changes.outputs.no_changes == 'true'
+        run: echo "develop と main の差分がないため、PRの作成をスキップします。"
+
+      - name: PRを作成
+        if: steps.get_changes.outputs.no_changes == 'false'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CHANGES: ${{ steps.get_changes.outputs.changes }}
+        run: |
+          DATE=$(TZ=Asia/Tokyo date '+%Y/%m/%d')
+
+          cat > pr_body.md << 'TEMPLATE_END'
+          ## 変更内容
+
+          TEMPLATE_END
+
+          echo "$CHANGES" >> pr_body.md
+
+          cat >> pr_body.md << 'TEMPLATE_END'
+
+          ---
+          *このPRは毎週月曜日に自動生成されます。*
+          TEMPLATE_END
+
+          gh pr create \
+            --base main \
+            --head develop \
+            --title "chore: 週次デプロイ (${DATE})" \
+            --body-file pr_body.md

--- a/.github/workflows/weekly-deploy-pr.yml
+++ b/.github/workflows/weekly-deploy-pr.yml
@@ -13,6 +13,9 @@ jobs:
       contents: write
       pull-requests: write
 
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/weekly-deploy-pr.yml
+++ b/.github/workflows/weekly-deploy-pr.yml
@@ -43,10 +43,11 @@ jobs:
             echo "no_changes=true" >> "$GITHUB_OUTPUT"
           else
             echo "no_changes=false" >> "$GITHUB_OUTPUT"
+            DELIM=$(openssl rand -hex 16)
             {
-              echo "changes<<EOF_CHANGES"
+              echo "changes<<${DELIM}"
               echo "$CHANGES"
-              echo "EOF_CHANGES"
+              echo "${DELIM}"
             } >> "$GITHUB_OUTPUT"
           fi
 


### PR DESCRIPTION
## 概要

毎週月曜日に `develop` → `main` のデプロイPRを自動生成する GitHub Actions ワークフローを追加します。

## 変更内容

- `.github/workflows/weekly-deploy-pr.yml` を新規追加
- 毎週月曜日 09:00 JST（`cron: '0 0 * * 1'`）に自動実行
- `workflow_dispatch` で手動実行も可能

## 動作仕様

1. `develop → main` でオープン中の前週PRを自動クローズ（クローズコメント付き）
2. `git log origin/main..origin/develop` で差分コミットを取得
3. 差分がない場合はPR作成をスキップ
4. `chore: 週次デプロイ (YYYY/MM/DD)` のタイトルでPRを作成し、変更コミット一覧をbodyに含める

## 補足（任意）

必要な権限は `GITHUB_TOKEN` の `pull-requests: write` のみで追加のシークレット設定は不要です。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 毎週月曜日午前9時（JST）に自動でリリース用プルリクエストを作成するワークフローを追加しました。開発ブランチからメインブランチへのマージプロセスが効率化され、既存のプルリクエストは自動的にクローズされます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->