### PR TITLE
feat: ブログ詳細ページに関連ブログセクションを追加

### DIFF
--- a/src/components/pages/blog/BlogDetail.astro
+++ b/src/components/pages/blog/BlogDetail.astro
@@ -3,15 +3,17 @@ import BlogMeta from "@/components/pages/blog/BlogMeta.astro";
 import BlogThumbnail from "@/components/pages/blog/BlogThumbnail.astro";
 import BlogBody from "@/components/pages/blog/BlogBody.astro";
 import BlogShare from "@/components/pages/blog/BlogShare.astro";
+import RelatedBlogSection from "@/components/pages/blog/RelatedBlogSection.astro";
 import type { Blog } from "@/types/blog";
 import { SITE_TITLE } from "@/consts";
 import { Icon } from "astro-icon/components";
 
 interface Props {
   blog: Blog;
+  relatedBlogs: Blog[];
 }
 
-const { blog } = Astro.props;
+const { blog, relatedBlogs } = Astro.props;
 ---
 
 <a href="/blogs" class="flex items-center text-sm text-gray-500 mb-4">
@@ -29,6 +31,8 @@ const { blog } = Astro.props;
   />
   <BlogShare title={`${blog.title} | ${SITE_TITLE}`} />
 </article>
+
+<RelatedBlogSection relatedBlogs={relatedBlogs} />
 
 <style>
   main {

--- a/src/components/pages/blog/RelatedBlogSection.astro
+++ b/src/components/pages/blog/RelatedBlogSection.astro
@@ -1,0 +1,71 @@
+---
+import type { Blog } from "@/types/blog";
+import BlogCard from "@/components/pages/blogs/BlogCard.astro";
+import "../blogs/BlogPage.css";
+
+interface Props {
+  relatedBlogs: Blog[];
+}
+
+const { relatedBlogs } = Astro.props;
+---
+
+{relatedBlogs.length > 0 && (
+  <section class="related-blogs blog-page">
+    <h2 class="related-blogs__title">関連ブログ</h2>
+    <ul class="card-list">
+      {relatedBlogs.map((blog) => <BlogCard blog={blog} />)}
+    </ul>
+  </section>
+)}
+
+<style>
+  .related-blogs {
+    margin-top: 3rem;
+    padding-top: 2rem;
+    border-top: 1px solid rgba(var(--border), 90%);
+  }
+
+  .related-blogs__title {
+    margin: 0 0 1rem;
+    font-size: 1rem;
+    font-weight: 600;
+    color: rgb(var(--black));
+  }
+</style>
+
+<style is:global>
+  .related-blogs.blog-page .card-list {
+    grid-template-columns: repeat(3, 1fr);
+  }
+
+  /* first-childの全幅表示を無効化 */
+  .related-blogs.blog-page .card-list .card:first-child {
+    grid-column: auto;
+  }
+
+  /* 全カードの画像を16:9に統一（3:2と3:1の上書き） */
+  .related-blogs.blog-page .card-image-wrap,
+  .related-blogs.blog-page .card-list .card:first-child .card-image-wrap {
+    aspect-ratio: 16 / 9;
+  }
+
+  /* first-childの特別スタイルをリセット */
+  .related-blogs.blog-page .card-list .card:first-child .card-body {
+    padding: 0.6rem 0.75rem;
+  }
+
+  .related-blogs.blog-page .card-list .card:first-child .card-title {
+    font-size: 0.95rem;
+  }
+
+  .related-blogs.blog-page .card-list .card:first-child .card-image-placeholder {
+    font-size: 1.5rem;
+  }
+
+  @media (max-width: 720px) {
+    .related-blogs.blog-page .card-list {
+      grid-template-columns: 1fr;
+    }
+  }
+</style>

--- a/src/libs/microcms.ts
+++ b/src/libs/microcms.ts
@@ -38,3 +38,39 @@ export const getBlogDetail = async (contentId: string, queries?: MicroCMSQueries
 export const getActivities = async (queries?: MicroCMSQueries) => {
 	return await client.getAllContents<Activity>({ endpoint: "activities", queries });
 };
+
+/** 関連ブログを最大 limit 件取得（カテゴリまたはタグが一致するもの優先、不足分は他の記事で補填） */
+export const getRelatedBlogs = async (blog: Blog, limit: number = 3): Promise<Blog[]> => {
+	const filterParts: string[] = [];
+
+	if (blog.category) {
+		filterParts.push(`category[equals]${blog.category.id}`);
+	}
+	for (const tag of blog.tags) {
+		filterParts.push(`tags[contains]${tag.id}`);
+	}
+
+	let relatedBlogs: Blog[] = [];
+
+	if (filterParts.length > 0) {
+		const response = await getBlogs({
+			limit: limit + 1,
+			filters: filterParts.join("[or]"),
+			depth: 2,
+		});
+		relatedBlogs = response.contents.filter((b) => b.id !== blog.id).slice(0, limit);
+	}
+
+	if (relatedBlogs.length < limit) {
+		const needed = limit - relatedBlogs.length;
+		const excludeIds = new Set([blog.id, ...relatedBlogs.map((b) => b.id)]);
+		const response = await getBlogs({
+			limit: needed + excludeIds.size,
+			depth: 2,
+		});
+		const additional = response.contents.filter((b) => !excludeIds.has(b.id)).slice(0, needed);
+		relatedBlogs = [...relatedBlogs, ...additional];
+	}
+
+	return relatedBlogs;
+};

--- a/src/pages/blogs/[...slug].astro
+++ b/src/pages/blogs/[...slug].astro
@@ -1,7 +1,7 @@
 ---
 import BaseLayout from "@/layouts/BaseLayout.astro";
 import BlogDetail from "@/components/pages/blog/BlogDetail.astro";
-import { getAllBlogIds, getBlogDetail } from "@/libs/microcms";
+import { getAllBlogIds, getBlogDetail, getRelatedBlogs } from "@/libs/microcms";
 
 export async function getStaticPaths() {
 	const ids = await getAllBlogIds();
@@ -15,6 +15,7 @@ const blogId = Array.isArray(slug) ? slug[0] : (slug ?? "");
 const blog = await getBlogDetail(blogId, {
 	depth: 2,
 });
+const relatedBlogs = await getRelatedBlogs(blog);
 ---
 
 <BaseLayout
@@ -23,5 +24,5 @@ const blog = await getBlogDetail(blogId, {
   image={blog.eyecatch?.url}
   path={`/blogs/${blogId}`}
 >
-  <BlogDetail blog={blog} />
+  <BlogDetail blog={blog} relatedBlogs={relatedBlogs} />
 </BaseLayout>


### PR DESCRIPTION
## Summary

- `getRelatedBlogs()` をmicroCMSクライアントに追加。カテゴリまたはタグが1つ以上一致する記事を最大3件取得し、不足時は他の記事で補填
- `RelatedBlogSection.astro` コンポーネントを新規作成。既存の `BlogCard` を再利用し3カラムグリッドで表示
- ブログ詳細ページ（`[...slug].astro` / `BlogDetail.astro`）に上記を組み込み、シェアボタンの下に配置

Closes #48

## Test plan

- [ ] ブログ詳細ページ下部に「関連ブログ」セクションが表示される
- [ ] カテゴリまたはタグが一致する記事が優先表示される
- [ ] 3件未満の場合は他の記事で補填されている
- [ ] 現在の記事自身が関連ブログに含まれていない
- [ ] モバイルで1カラム表示になる

🤖 Generated with [Claude Code](https://claude.com/claude-code)