### PR TITLE
feat: microCMS画面プレビュー機能を追加

### DIFF
--- a/src/libs/microcms.ts
+++ b/src/libs/microcms.ts
@@ -34,6 +34,20 @@ export const getBlogDetail = async (contentId: string, queries?: MicroCMSQueries
 	});
 };
 
+/** 下書きを含む全記事 ID を取得（ビルド時のプレビューページ生成用） */
+export const getAllBlogIdsIncludingDraft = async () => {
+	return await client.getAllContentIds({ endpoint: "blogs" });
+};
+
+/** 下書きを含む記事詳細を取得（ビルド時のプレビューページ生成用） */
+export const getBlogDetailIncludingDraft = async (contentId: string) => {
+	return await client.getListDetail<Blog>({
+		endpoint: "blogs",
+		contentId,
+		queries: { depth: 2 },
+	});
+};
+
 /** アクティビティ一覧を取得 */
 export const getActivities = async (queries?: MicroCMSQueries) => {
 	return await client.getAllContents<Activity>({ endpoint: "activities", queries });

--- a/src/pages/draft/blogs/[id].astro
+++ b/src/pages/draft/blogs/[id].astro
@@ -1,0 +1,23 @@
+---
+import BaseLayout from "@/layouts/BaseLayout.astro";
+import BlogDetail from "@/components/pages/blog/BlogDetail.astro";
+import { getAllBlogIdsIncludingDraft, getBlogDetailIncludingDraft, getRelatedBlogs } from "@/libs/microcms";
+
+export async function getStaticPaths() {
+  const ids = await getAllBlogIdsIncludingDraft();
+  return ids.map((id) => ({ params: { id } }));
+}
+
+const { id } = Astro.params;
+const blog = await getBlogDetailIncludingDraft(id);
+const relatedBlogs = await getRelatedBlogs(blog);
+---
+
+<BaseLayout
+  title={blog.title}
+  description={blog.description}
+  image={blog.eyecatch?.url}
+  noIndex={true}
+>
+  <BlogDetail blog={blog} relatedBlogs={relatedBlogs} />
+</BaseLayout>


### PR DESCRIPTION
## 概要

microCMS管理画面の「画面プレビュー」機能に対応しました。
下書き保存時のwebhookで再ビルドをトリガーし、ビルド時に下書き記事を静的ページとして生成します。

## 変更内容

- `getAllBlogIdsIncludingDraft()` を追加（APIキーの権限に従い下書き含む全記事IDを取得）
- `getBlogDetailIncludingDraft()` を追加（下書き含む記事詳細を取得）
- `/draft/blogs/[id].astro` を追加（静的生成、`noIndex: true`）

## microCMS側の設定

**API設定 → 画面プレビュー** の「遷移先URL」に以下を設定してください：

```
https://<サイトURL>/draft/blogs/{CONTENT_ID}
```

また、APIキーに「下書きを含むコンテンツの取得を許可する」権限が必要です。

## 動作

1. microCMS管理画面で記事を下書き保存
2. webhookが発火してビルドをトリガー
3. ビルド時に `/draft/blogs/{id}` として静的ページを生成
4. 管理画面のプレビューボタンから確認可能